### PR TITLE
V0.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,3 +3,14 @@
 * Add `reversed(Route(node_1 ... node_n).edges)` to walk through nodes backwards.
 * Add `BinaryTree` and `BinaryDownTree` abstract classes.
 * Add `tree.levels.zigzag()` method to iterate through levels in [zigzag-order](https://www.geeksforgeeks.org/zigzag-tree-traversal/).
+
+## Version 0.1.0
+
+* `UpTree` is no longer exported by default, although it can still be imported.
+  It has been removed from the documentation and is considered for deletion.
+* Add `AbstractTree.convert(obj)` as a type-aware replacement for `astree(obj)`.
+  For instance, `DownTree.convert(obj)` can be used if `obj.parent` doesn't exist.
+* Rename `treeclasses.py` to `tree.py`
+* Rename `conversions.py` to `adapters.py`
+* Don't special-case `x in node.ancestors` to use identity comparison.
+* `to_dot` and `to_mermaid` now generate nodes in levelorder (breadth first), instead of preorder (depth-first)

--- a/README.md
+++ b/README.md
@@ -5,15 +5,13 @@ This package defines abstract base classes for these data structure in order to 
 ## Abstract base classes ##
 
 ```python
-from abstracttree import to_mermaid
+from abstracttree import DownTree, to_mermaid
 
-to_mermaid(AbstractTree)
+to_mermaid(DownTree)
 ```
 
 ```mermaid
 graph TD;
-AbstractTree[AbstractTree];
-UpTree[UpTree];
 Tree[Tree];
 MutableTree[MutableTree];
 DownTree[DownTree];
@@ -21,34 +19,28 @@ Tree[Tree];
 MutableTree[MutableTree];
 MutableDownTree[MutableDownTree];
 MutableTree[MutableTree];
-BinaryDownTree[BinaryDownTree]
-BinaryTree[BinaryTree]
-AbstractTree-->UpTree;
-UpTree-->Tree;
+BinaryDownTree[BinaryDownTree];
+BinaryTree[BinaryTree];
 Tree-->MutableTree;
-AbstractTree-->DownTree;
 DownTree-->Tree;
 DownTree-->MutableDownTree;
 MutableDownTree-->MutableTree;
-DownTree-->BinaryDownTree
-BinaryDownTree-->BinaryTree
-Tree-->BinaryTree
+DownTree-->BinaryDownTree;
+BinaryDownTree-->BinaryTree;
+Tree-->BinaryTree;
 ```
 
-Downtrees are trees that have links to their direct children.
-Uptrees are trees that link to their parent.
-A Tree has links in both directions.
+`Downtrees` need to have links to their direct children, but don't require a link to their parent.
+A `Tree` needs to have links to `children` and `parent`.
 
-| ABC               | Inherits from               | Abstract Methods                  | Mixin Methods                                                                                                                        |
-|-------------------|-----------------------------|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| `AbstractTree`    |                             |                                   | `nid`, `eqv()`                                                                                                                       |
-| `UpTree`          | `AbstractTree`              | `parent`                          | `root`, `is_root`, `ancestors`, `path`                                                                                               |
-| `DownTree`        | `AbstractTree`              | `children`                        | `nodes`, `descendants`, `leaves`, `levels`, `is_leaf`, `transform()`, `nodes.preorder()`, `nodes.postorder()`, `nodes.levelorder()`  |
-| `Tree`            | `UpTree`, `DownTree`        |                                   | `siblings`                                                                                                                           |
-| `MutableDownTree` | `DownTree`                  | `add_child()`, `remove_child()`   | `add_children()`                                                                                                                     |
-| `MutableTree`     | `Tree`, `MutableDownTree`   |                                   | `detach()`                                                                                                                           |
-| `BinaryDownTree`  | `DownTree`                  | `left_child`, `right_child`       | `children`, `nodes.inorder()`, `descendants.inorder()`                                                                               |
-| `BinaryTree`      | `BinaryDownTree`, `Tree`    |                                   |                                                                                                                                      |
+| ABC               | Inherits from             | Abstract Methods                | Mixin Methods                                                                                                                                       |
+|-------------------|---------------------------|---------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DownTree`        |                           | `children`                      | `nodes`, `descendants`, `leaves`, `levels`, `is_leaf`, `transform()`, `nodes.preorder()`, `nodes.postorder()`, `nodes.levelorder()`, `nid`, `eqv()` |
+| `Tree`            | `DownTree`                | `parent`                        | `root`, `is_root`, `ancestors`, `path`, `siblings`                                                                                                  |
+| `MutableDownTree` | `DownTree`                | `add_child()`, `remove_child()` | `add_children()`                                                                                                                                    |
+| `MutableTree`     | `Tree`, `MutableDownTree` |                                 | `detach()`                                                                                                                                          |
+| `BinaryDownTree`  | `DownTree`                | `left_child`, `right_child`     | `children`, `nodes.inorder()`, `descendants.inorder()`                                                                                              |
+| `BinaryTree`      | `BinaryDownTree`, `Tree`  |                                 |                                                                                                                                                     |
 
 In your own code, you can inherit from these trees.
 For example, if your tree only has links to children:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 This Python package contains a few abstract base classes for tree data structures.
 Trees are very common data structure that represents a hierarchy of common nodes.
-This package defines abstract base classes for these data structure in order to make code reusable.
+There are many different ways to represent them.
+This package tries to provide a uniform interface, mixin methods and some utility functions without settling on a concrete tree implementation.
 
 ## Abstract base classes ##
 
@@ -30,17 +31,17 @@ BinaryDownTree-->BinaryTree;
 Tree-->BinaryTree;
 ```
 
-`Downtrees` need to have links to their direct children, but don't require a link to their parent.
-A `Tree` needs to have links to `children` and `parent`.
+A `Downtree` needs to have links to its direct children, but doesn't require a link to its parent.
+A `Tree` needs to have links to both its `children` and its `parent`.
 
-| ABC               | Inherits from             | Abstract Methods                | Mixin Methods                                                                                                                                       |
-|-------------------|---------------------------|---------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DownTree`        |                           | `children`                      | `nodes`, `descendants`, `leaves`, `levels`, `is_leaf`, `transform()`, `nodes.preorder()`, `nodes.postorder()`, `nodes.levelorder()`, `nid`, `eqv()` |
-| `Tree`            | `DownTree`                | `parent`                        | `root`, `is_root`, `ancestors`, `path`, `siblings`                                                                                                  |
-| `MutableDownTree` | `DownTree`                | `add_child()`, `remove_child()` | `add_children()`                                                                                                                                    |
-| `MutableTree`     | `Tree`, `MutableDownTree` |                                 | `detach()`                                                                                                                                          |
-| `BinaryDownTree`  | `DownTree`                | `left_child`, `right_child`     | `children`, `nodes.inorder()`, `descendants.inorder()`                                                                                              |
-| `BinaryTree`      | `BinaryDownTree`, `Tree`  |                                 |                                                                                                                                                     |
+| ABC               | Inherits from             | Abstract Methods                | Mixin Methods                                                                                                                                                           |
+|-------------------|---------------------------|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DownTree`        |                           | `children`                      | `nodes`, `nodes.preorder()`, `nodes.postorder()`, `nodes.levelorder()`, `descendants`, `leaves`, `levels`, `levels.zigzag()`, `is_leaf`, `transform()`,  `nid`, `eqv()` |
+| `Tree`            | `DownTree`                | `parent`                        | `root`, `is_root`, `ancestors`, `path`, `siblings`                                                                                                                      |
+| `MutableDownTree` | `DownTree`                | `add_child()`, `remove_child()` | `add_children()`                                                                                                                                                        |
+| `MutableTree`     | `Tree`, `MutableDownTree` |                                 | `detach()`                                                                                                                                                              |
+| `BinaryDownTree`  | `DownTree`                | `left_child`, `right_child`     | `children`, `nodes.inorder()`, `descendants.inorder()`                                                                                                                  |
+| `BinaryTree`      | `BinaryDownTree`, `Tree`  |                                 |                                                                                                                                                                         |
 
 In your own code, you can inherit from these trees.
 For example, if your tree only has links to children:
@@ -73,23 +74,27 @@ print_tree(tree)
 ## Adapter ##
 
 In practice, not all existing tree data structures implement one of these abstract classes.
-As a bridge, you can use `astree` to convert these trees to a `Tree` instance.
+As a bridge, you can use `AbstractTree.convert` to convert these trees to a `Tree` instance.
 However, whenever possible, it's recommended to inherit from `Tree` directly for minimal overhead.
 
 Examples:
 
 ```python
 # Trees from built-ins and standard library
-astree(int)
-astree(ast.parse("1 + 1 == 2"))
-astree(pathlib.Path("abstracttree"))
+tree = Tree.convert(int)
+tree = Tree.convert(ast.parse("1 + 1 == 2"))
+tree = Tree.convert(pathlib.Path("abstracttree"))
 
 # Anything that has parent and children attributes (anytree / bigtree / littletree)
-astree(anytree.Node())
+tree = Tree.convert(anytree.Node('name'))
 
 # Nested list
-astree([[1, 2, 3], [4, 5, 6]])
+tree = Tree.convert([[1, 2, 3], [4, 5, 6]])
+```
 
+Or use `astree` if you need a custom function for `parent` or `children`:
+
+```python
 # Tree from json-data
 data = {"name": "a",
         "children": [
@@ -158,10 +163,8 @@ from abstracttree import HeapTree, Route
 
 tree = HeapTree([5, 4, 3, 2, 1])
 heapq.heapify(tree.heap)
-left_child = tree.children[0]
-right_child = tree.children[1]
+route = Route(tree.left_child, tree.right_child)
 
-route = Route(left_child, right_child)
 print(f"{route.lca = }")  # => HeapTree([1, 2, 3, 5, 4], 0)
 print(f"{route.nodes.count() = }")  # => 3
 print(f"{route.edges.count() = }")  # => 2

--- a/abstracttree/__init__.py
+++ b/abstracttree/__init__.py
@@ -1,7 +1,6 @@
 __all__ = [
     "Tree",
     "DownTree",
-    "UpTree",
     "MutableTree",
     "MutableDownTree",
     "BinaryTree",
@@ -29,6 +28,6 @@ from .export import print_tree, plot_tree, to_image, to_dot, to_mermaid, to_stri
 from .heaptree import HeapTree
 from .predicates import RemoveDuplicates, PreventCycles, MaxDepth
 from .route import Route
-from .treeclasses import Tree, DownTree, UpTree, MutableDownTree, MutableTree
+from .treeclasses import Tree, DownTree, MutableDownTree, MutableTree
 
 __version__ = "0.0.5"

--- a/abstracttree/__init__.py
+++ b/abstracttree/__init__.py
@@ -21,13 +21,13 @@ __all__ = [
     "Route",
 ]
 
+from .adapters import astree
 from .binarytree import BinaryTree, BinaryDownTree
-from .conversions import astree
 from .export import print_tree, plot_tree, to_image, to_dot, to_mermaid, to_string, to_pillow, \
     to_latex
 from .heaptree import HeapTree
 from .predicates import RemoveDuplicates, PreventCycles, MaxDepth
 from .route import Route
-from .treeclasses import Tree, DownTree, MutableDownTree, MutableTree
+from .tree import Tree, DownTree, MutableDownTree, MutableTree
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"

--- a/abstracttree/adapters.py
+++ b/abstracttree/adapters.py
@@ -7,7 +7,7 @@ import zipfile
 from collections.abc import Sequence, Mapping
 from typing import TypeVar, Callable, Iterable, overload, Collection, Union
 
-from .treeclasses import Tree, DownTree
+from .tree import Tree, DownTree
 
 TWrap = TypeVar("TWrap")
 BaseString = Union[str, bytes, bytearray]  # Why did they ever remove this type?

--- a/abstracttree/binarytree.py
+++ b/abstracttree/binarytree.py
@@ -2,9 +2,9 @@ from abc import ABCMeta, abstractmethod
 from collections import deque
 from typing import Optional, Sequence
 
-from abstracttree import treeclasses
+from abstracttree import tree
 
-from .treeclasses import DownTree, Tree, TNode, NodeItem
+from .tree import DownTree, Tree, TNode, NodeItem
 
 
 class BinaryDownTree(DownTree, metaclass=ABCMeta):
@@ -44,7 +44,7 @@ class BinaryTree(BinaryDownTree, Tree, metaclass=ABCMeta):
     __slots__ = ()
 
 
-class NodesView(treeclasses.NodesView):
+class NodesView(tree.NodesView):
     """Extend NodesView to make it do inorder."""
     __slots__ = ()
 

--- a/abstracttree/export.py
+++ b/abstracttree/export.py
@@ -23,8 +23,6 @@ __all__ = [
     "LiteralText",
 ]
 
-from .conversions import astree
-
 
 class Style(TypedDict):
     branch: str
@@ -89,7 +87,7 @@ def to_string(
     keep=None,
 ):
     """Converts tree to a string in a pretty format."""
-    tree = astree(tree)
+    tree = Tree.convert(tree)
     if isinstance(style, str):
         style = DEFAULT_STYLES[style]
     empty_style = len(style["last"]) * " "
@@ -133,7 +131,7 @@ def plot_tree(tree: Tree, ax=None, formatter=str, keep=DEFAULT_PREDICATE, annota
     """Plot the tree using matplotlib (if installed)."""
     # Roughly based on sklearn.tree.plot_tree()
     import matplotlib.pyplot as plt
-    tree = astree(tree)
+    tree = Tree.convert(tree)
 
     if ax is None:
         ax = plt.gca()
@@ -250,7 +248,7 @@ def to_dot(
     graph_attributes: GraphAttributes = None,
 ):
     """Export to `graphviz <https://graphviz.org/>`_."""
-    tree = astree(tree)
+    tree = Tree.convert(tree)
     if node_name is None:
         node_name = _node_name_default
 
@@ -349,7 +347,7 @@ def to_mermaid(
     graph_direction: str = "TD",
 ):
     """Export to `mermaid <https://mermaid.js.org/>`_."""
-    tree = astree(tree)
+    tree = Tree.convert(tree)
     if node_name is None:
         node_name = _node_name_default
 
@@ -401,7 +399,7 @@ def to_latex(
     Make sure to put ``\\usepackage{tikz}`` in your preamble.
     Does not wrap output in a figure environment.
     """
-    tree = astree(tree)
+    tree = DownTree.convert(tree)
     if isinstance(indent, int):
         indent = "\t" if indent == -1 else indent * " "
 

--- a/abstracttree/export.py
+++ b/abstracttree/export.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Union, Callable, TypedDict, Tuple, Any, TypeVar, Optional
 
 from .predicates import PreventCycles, MaxDepth
-from .treeclasses import DownTree, Tree
+from .tree import DownTree, Tree
 
 __all__ = [
     "print_tree",

--- a/abstracttree/export.py
+++ b/abstracttree/export.py
@@ -282,7 +282,7 @@ def to_dot(
         file.write(f"edge{attrs};\n")
 
     nodes = []
-    for node, _ in tree.nodes.preorder(keep=PreventCycles() & keep):
+    for node, _ in tree.nodes.levelorder(keep=PreventCycles() & keep):
         nodes.append(node)
         name = _escape_string(node_name(node), "dot")
         attrs = _handle_attributes(node_dynamic, node)
@@ -359,7 +359,7 @@ def to_mermaid(
 
     # Output nodes
     nodes = []  # Stop automatic garbage collecting
-    for node, _ in tree.nodes.preorder(keep=PreventCycles() & keep):
+    for node, _ in tree.nodes.levelorder(keep=PreventCycles() & keep):
         left, right = _get_shape(node_shape, node)
         name = node_name(node)
         if node_label:

--- a/abstracttree/heaptree.py
+++ b/abstracttree/heaptree.py
@@ -1,7 +1,7 @@
 from typing import Collection, Optional
 
 from .binarytree import BinaryTree
-from .treeclasses import TNode
+from .tree import TNode
 
 
 class HeapTree(BinaryTree):

--- a/abstracttree/predicates.py
+++ b/abstracttree/predicates.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Callable
 
-from .treeclasses import AbstractTree, NodeItem
+from .tree import AbstractTree, NodeItem
 
 
 class Predicate(Callable[[AbstractTree, NodeItem], bool]):

--- a/abstracttree/predicates.py
+++ b/abstracttree/predicates.py
@@ -68,7 +68,7 @@ class PreventCycles(Predicate):
         self.duplicates = set()
 
     def __call__(self, node: AbstractTree, item):
-        if node.parent and node.parent.nid in self.duplicates:
+        if node.parent is not None and node.parent.nid in self.duplicates and node.nid in self.seen:
             return False
         if node.nid in self.seen:
             self.duplicates.add(node.nid)
@@ -85,7 +85,7 @@ class MaxDepth(Predicate):
     Can be passed to keep argument of methods such as tree.iter_tree().
     >>> from littletree import Node
     >>> tree = Node(identifier='root').path.create(['a', 'b', 'c', 'd']).root
-    >>> [node.identifier for node in tree.iter_nodes(keep=MaxDepth(3))]
+    >>> [node.identifier for node in tree.nodes.preorder(keep=MaxDepth(3))]
     ['root', 'a', 'b', 'c']
     """
     depth: int

--- a/abstracttree/route.py
+++ b/abstracttree/route.py
@@ -5,7 +5,7 @@ from collections.abc import Sized, Sequence, MutableSequence
 from functools import lru_cache
 from typing import TypeVar, Optional
 
-from .treeclasses import UpTree
+from .tree import UpTree
 
 TNode = TypeVar("TNode", bound=UpTree)
 

--- a/abstracttree/tree.py
+++ b/abstracttree/tree.py
@@ -18,7 +18,7 @@ class AbstractTree(metaclass=ABCMeta):
     @classmethod
     def convert(cls, obj):
         """Convert obj to tree-type or raise TypeError if that doesn't work."""
-        from .conversions import convert_tree
+        from .adapters import convert_tree
         if isinstance(obj, cls):
             return obj
         tree = convert_tree(obj)

--- a/abstracttree/tree.py
+++ b/abstracttree/tree.py
@@ -31,7 +31,7 @@ class AbstractTree(metaclass=ABCMeta):
         """Unique number that represents this node."""
         return id(self)
 
-    def eqv(self, other):
+    def eqv(self, other) -> bool:
         """Check if both objects represent the same node.
 
         Should normally be operator.is, but can be overridden by delegates.
@@ -174,9 +174,6 @@ class TreeView(Iterable[TNode], metaclass=ABCMeta):
         deque(zip(self, counter), maxlen=0)
         return next(counter)
 
-    def __contains__(self, node) -> bool:
-        return any(map(node.eqv, self))
-
 
 class AncestorsView(TreeView):
     __slots__ = "parent"
@@ -316,7 +313,7 @@ class LeavesView(TreeView):
         except AttributeError:
             return node in super()
         else:
-            return any(map(self.root.eqv, ancestors))
+            return self.root in ancestors
 
 
 class LevelsView:

--- a/abstracttree/treeclasses.py
+++ b/abstracttree/treeclasses.py
@@ -15,6 +15,17 @@ class AbstractTree(metaclass=ABCMeta):
     """Most abstract baseclass for everything."""
     __slots__ = ()
 
+    @classmethod
+    def convert(cls, obj):
+        """Convert obj to tree-type or raise TypeError if that doesn't work."""
+        from .conversions import convert_tree
+        if isinstance(obj, cls):
+            return obj
+        tree = convert_tree(obj)
+        if isinstance(tree, cls):
+            return tree
+        raise TypeError(f"{obj!r} cannot be converted to {cls.__name__}")
+
     @property
     def nid(self) -> int:
         """Unique number that represents this node."""

--- a/examples/networkx_example.py
+++ b/examples/networkx_example.py
@@ -8,7 +8,7 @@ Since networkx has a very different data model it makes most sense to work with 
 import networkx as nx
 
 from abstracttree import print_tree
-from abstracttree.conversions import TreeAdapter
+from abstracttree.adapters import TreeAdapter
 
 
 class NetworkXTree(TreeAdapter):

--- a/examples/sklearn_example.py
+++ b/examples/sklearn_example.py
@@ -2,7 +2,7 @@
 # https://github.com/scikit-learn/scikit-learn/pull/28364
 
 from abstracttree import print_tree, to_latex, to_image
-from abstracttree.conversions import StoredParent
+from abstracttree.adapters import StoredParent
 
 
 class DecisionTreeAdapter(StoredParent):

--- a/tests/tree_instances.py
+++ b/tests/tree_instances.py
@@ -53,7 +53,7 @@ class InfiniteSingleton(Tree):
 
 
 SINGLETON = astree("Singleton", children=lambda n: ())
-NONEXISTENTPATH = astree(Path("this/path/should/not/exist"))
+NONEXISTENTPATH = Tree.convert(Path("this/path/should/not/exist"))
 
 BINARY_TREE = BinaryNode(1)  # 2 children
 BINARY_TREE.left = BinaryNode(2)  # leaf
@@ -71,7 +71,7 @@ COUNTDOWN = astree(COUNTDOWN_MAX,
                    children=lambda n: [n + 1] if n < COUNTDOWN_MAX else (),
                    parent=lambda n: n - 1 if n > 0 else None)
 
-SEQTREE = astree([1, [2, 3], []])
+SEQTREE = Tree.convert([1, [2, 3], []])
 
 INFINITE_TREE = InfiniteSingleton()
 


### PR DESCRIPTION
* `UpTree` is no longer exported by default, although it can still be imported.
  It has been removed from the documentation and is considered for deletion.
* Add `AbstractTree.convert(obj)` as a type-aware replacement for `astree(obj)`.
  For instance, `DownTree.convert(obj)` can be used if `obj.parent` doesn't exist.
* Rename `treeclasses.py` to `tree.py`
* Rename `conversions.py` to `adapters.py`
* Don't special-case `x in node.ancestors` to use identity comparison.
* `to_dot` and `to_mermaid` now generate nodes in levelorder (breadth first), instead of preorder (depth-first)
